### PR TITLE
Properly declare the member functions

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -18,7 +18,7 @@ export default {
     }
   },
 
-  activate: () => {
+  activate() {
     require('atom-package-deps').install('squirrel-linter');
 
     if (atom.config.get("squirrel-linter.verbose")) {
@@ -26,7 +26,7 @@ export default {
     }
   },
 
-  provideLinter: () => {
+  provideLinter() {
     const atomLinter = require("atom-linter");
 
     return {


### PR DESCRIPTION
Function declaration using an arrow function in the global scope is invalid, and the cleaner transpilation in Atom v1.16.0 breaks on this method.

See https://github.com/atom/atom/pull/13823#issuecomment-286985411 for details.